### PR TITLE
📦 NEW: Add Increment and Decrement

### DIFF
--- a/src/Utils/increment.ts
+++ b/src/Utils/increment.ts
@@ -1,0 +1,9 @@
+import { BigInt } from "@graphprotocol/graph-ts"
+
+export function incrementBigInt(num: BigInt, amount: BigInt = BigInt.fromI32(1)): BigInt {
+    return num.plus(amount)
+}
+
+export function decrementBigInt(num: BigInt, amount: BigInt = BigInt.fromI32(1)): BigInt {
+    return num.plus(amount)
+}


### PR DESCRIPTION
For counting I frequently need to increment and decrement BigInt amounts. Often only by 1, and the repeated `BigInt.fromI32(1)` isn't "DRY". 

`incrementBigInt()` and `decrementBigInt()` both take the `num` that you wish to increment and by default increment or decrement by `BigInt` 1. If you pass a second argument: `amount`  (also a BigInt) it will increment or decrement by that amount. 