### PR TITLE
feat: allow custom root

### DIFF
--- a/scripts/graph-compiler/cli.js
+++ b/scripts/graph-compiler/cli.js
@@ -13,6 +13,7 @@ const argv = require('yargs')
   .option('include',         { type: 'array',   default: []                                           })
   .option('export-schema',   { type: 'boolean', default: false                                        })
   .option('export-subgraph', { type: 'boolean', default: false                                        })
+  .option('root',            { type: 'string',  default: '.' })
   .argv;
 
 const config = new Config(argv);

--- a/scripts/graph-compiler/config.js
+++ b/scripts/graph-compiler/config.js
@@ -24,6 +24,10 @@ class Config {
     return this._cfg.datasources.flatMap(({ templates }) => templates).filter(Boolean).unique();
   }
 
+  root() {
+    return this._argv.root;
+  }
+
   schemaPath()   { return `${this._cfg.output}schema.graphql`; }
   subgraphPath() { return `${this._cfg.output}subgraph.yaml`;  }
 }

--- a/scripts/graph-compiler/subgraph/subgraph.js
+++ b/scripts/graph-compiler/subgraph/subgraph.js
@@ -39,7 +39,7 @@ class Subgraph {
           config._cfg,
           {
             id:   array.findIndex(({ module }) => module === datasource.module) === i ? datasource.module : `${datasource.module}-${i}`,
-            root: relative('.'),
+            root: relative(config.root()),
             file: relative(modules[datasource.module].ts),
           },
           datasource,
@@ -60,7 +60,7 @@ class Subgraph {
           config._cfg,
           {
             id:   template,
-            root: relative('.'),
+            root: relative(config.root()),
           },
         ))
         .map(template => [].concat(


### PR DESCRIPTION
We work inside of an NX monorepo combined with Yarn 3. this poses some challenges as NX likes the node modules folder to be at the top level.

In this package the location of the node modules folder was based on the package, which points to a non existing folder in such a monorepo. 

By adding a config variable for the root path, defaulting to the original location, we can use this inside the monorepo.