### PR TITLE
fix: event types have changed in 0.26.0 causing typescript errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"yargs": "^17.2.1"
 	},
 	"devDependencies": {
-		"@graphprotocol/graph-cli": "^0.26.0"
+		"@graphprotocol/graph-cli": "^0.29.0"
 	},
 	"engines": {
 		"node" : ">=0.12"

--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
 		"test": "graph build testing/subgraph.yaml"
 	},
 	"dependencies": {
-		"@graphprotocol/graph-ts": "^0.24.0",
+		"@graphprotocol/graph-ts": "^0.26.0",
 		"yargs": "^17.2.1"
 	},
 	"devDependencies": {
-		"@graphprotocol/graph-cli": "^0.24.0"
+		"@graphprotocol/graph-cli": "^0.26.0"
 	},
 	"engines": {
 		"node" : ">=0.12"


### PR DESCRIPTION
```
      let offer = MarketplaceOffer.load(events.id(event));
```

the 0.24 types of 'event' are not compatible with the 0.26 types

Workaround right now is to use yarn resolutions

```
  "resolutions": {
    "@graphprotocol/graph-ts": "0.26.0"
  }
```